### PR TITLE
Health check endpoint

### DIFF
--- a/ruby/sinatra/app.rb
+++ b/ruby/sinatra/app.rb
@@ -18,8 +18,8 @@ storage = InMemory.new
 service = VideoGames.new storage, VideoGame
 controller = Controller.new service
 
-get '/' do
-    'Hello World!'
+get '/ping' do
+    'pong'
 end
 
 if %w[TEST DEV].include? environment


### PR DESCRIPTION
For all applications there should be an endpoint at `/ping` which returns `pong` via a GET request.
This pull request adds this functionality to the ruby/sinatra api.

I'm removing the Hello World example.