### PR TITLE
Refactoring Docker build, run & clean up scripts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,11 +43,9 @@ pipeline {
             steps {
                 script {
                     try {
-                        echo "Running build script; ${buildPath}/scripts/build_img.sh"
-                        dir(buildPath) {
-                            sh 'chmod 700 -R ./scripts'
-                            sh './scripts/build_img.sh'
-                        }
+                        echo "Running build script; ./scripts/build.sh ${buildPath}"
+                        sh 'chmod 700 -R ./scripts'
+                        sh "./scripts/build.sh ${buildPath}"
                     } catch (e) {
                         pullRequest.comment("BUILD FAILED ❌. SEE ERROR MESSAGE BELOW:\n${formatMessage(e.message)}")
                         throw e
@@ -65,10 +63,8 @@ pipeline {
             steps {
                 script {
                     try {
-                        echo "Running lint script; ${buildPath}/scripts/run_img.sh lint"
-                        dir(buildPath) {
-                            sh './scripts/run_img.sh lint'
-                        }
+                        echo "Running lint script; ./scripts/run.sh ${buildPath} lint"
+                        sh "./scripts/run.sh ${buildPath} lint"
                     } catch (e) {
                         pullRequest.comment("LINTING FAILED ❌. SEE ERROR MESSAGE BELOW:\n${formatMessage(e.message)}")
                         throw e
@@ -86,10 +82,8 @@ pipeline {
             steps {
                 script {
                     try {
-                        echo "Running src test script; ${buildPath}/scripts/run_img.sh test"
-                        dir(buildPath) {
-                            sh './scripts/run_img.sh test'
-                        }   
+                        echo "Running src test script; ./scripts/run.sh ${buildPath} test"
+                        sh "./scripts/run.sh ${buildPath} test"
                     } catch (e) {
                         pullRequest.comment("SRC TESTING FAILED ❌. SEE ERROR MESSAGE BELOW:\n${formatMessage(e.message)}")
                         throw e
@@ -107,10 +101,8 @@ pipeline {
             steps {
                 script {
                      try {
-                        echo "Running api script; ${buildPath}/scripts/run_img.sh"
-                        dir(buildPath) {
-                            sh './scripts/run_img.sh'
-                        }
+                        echo "Running api script; ./scripts/run.sh ${buildPath}"
+                        sh "./scripts/run.sh ${buildPath}"
                         sh 'curl -f http://localhost:8080/ping'
                     } catch (e) {
                         pullRequest.comment("HEALTH CHECK FAILED ❌. SEE ERROR MESSAGE BELOW:\n${formatMessage(e.message)}")
@@ -153,6 +145,16 @@ pipeline {
             steps {
                 script {
                     pullRequest.comment("BUILD SUCCESSFUL ✔️")
+                }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                if (isIntoMaster || isIntoLangFramework) {
+                    echo "Running clean up script; ./scripts/clean.sh ${buildPath}"
+                    sh "./scripts/clean.sh ${buildPath}"
                 }
             }
         }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# builds docker image for specified environment argument
+# must be passed the lang framework as argument in the form 'lang/framework'
+# e.g; ruby/sinatra
+
+# language and framework; used for pathing to Dockerfile
+LANG_FRAME=${1%/}
+
+# check lang/framework was passed
+if [ -z $LANG_FRAME ]
+    then
+        echo "Requires language and framework as first argument e.g; ruby/sinatra"
+        exit 1
+fi
+
+# check if directory for language and framework exists
+if ! dir $LANG_FRAME >/dev/null 2>&1
+    then
+        echo "A directory doesn't exist for '$LANG_FRAME'"
+        exit 1
+fi
+
+# environments; dev, test, prod
+ENV=$2
+
+# if env is null; assume dev
+if [ -z $ENV ]
+    then
+        echo "No environment specified as argument. Using dev." 
+        ENV=dev
+fi
+
+IMG_REF="$LANG_FRAME:$ENV"
+
+# check if image for environment already exists
+if docker image inspect $IMG_REF >/dev/null 2>&1
+    then
+        # check for running containers with image to stop
+        CONTAINERS=$(docker ps --filter ancestor=$IMG_REF --filter status=running --format {{.ID}})
+
+        # stop all discovered containers
+        for CONTAINER in $CONTAINERS; do
+            echo "Container with id '$CONTAINER' running with old image. Stopping container."
+            docker stop $CONTAINER >/dev/null 2>&1
+        done
+
+        # check for any containers with image to remove
+        CONTAINERS=$(docker ps --filter ancestor=$IMG_REF --format {{.ID}})
+
+        # remove all containers with image
+        for CONTAINER in $CONTAINERS; do
+            docker rm $CONTAINER >/dev/null 2>&1
+        done
+
+        echo "Image $IMG_REF already exists. Removing..."
+        docker rmi $IMG_REF
+fi
+
+# begin docker build
+case $ENV in
+
+    dev)
+        echo "Building docker image: $LANG_FRAME:dev"
+        docker build -t $IMG_REF $LANG_FRAME
+        ;;
+
+    prod)
+        echo "Building docker image: $LANG_FRAME:prod"
+        docker build -t $IMG_REF --build-arg env=prod $LANG_FRAME
+        ;;
+
+    *)
+        echo "Unknown environment given; '${ENV}'."
+        exit 1
+esac

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# cleans up running containers for specified lang/framework which is 
+# provided as an argument to this script
+
+# get lang/framework
+LANG_FRAME=${1%/}
+
+# get service name
+SERVICE_NAME=$(echo $LANG_FRAME | tr / _)
+
+# check if service name is populated
+if [ -z $SERVICE_NAME ]
+    then
+        echo "Requires language and framework as first argument e.g; ruby/sinatra"
+        exit 1
+fi
+
+# check if service container exists
+if ! docker container inspect $SERVICE_NAME >/dev/null 2>&1
+    then
+        echo "No container exists for $LANG_FRAME."
+        exit 0
+fi
+
+# check if service is running and stop
+if [ $(docker container inspect $SERVICE_NAME --format {{.State.Status}}) == running ]
+    then
+        docker stop $SERVICE_NAME >/dev/null 2>&1
+        echo "Stopped container for $LANG_FRAME"
+fi
+
+# check if container still exists in stopped state
+if docker container inspect $SERVICE_NAME >/dev/null 2>&1
+    then
+        echo "Removing stopped container for $LANG_FRAME"
+        docker rm $SERVICE_NAME
+fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# runs docker image for specified lang/framework. Must be passed as 
+# script argument
+
+# language and framework; used for pathing to Dockerfile
+LANG_FRAME=${1%/}
+
+# check lang/framework was passed
+if [ -z $LANG_FRAME ]
+    then
+        echo "Requires language and framework as first argument e.g; ruby/sinatra"
+        exit 1
+fi
+
+# build service name
+SERVICE_NAME=$(echo $LANG_FRAME | tr / _)
+
+# commands; run_prod, run_dev, test, lint
+CMD=$2
+
+# if cmd is null; assume run_dev
+if [ -z $CMD ]
+    then
+        echo "No command specified as argument. Using 'run_dev'."
+        CMD=run_dev
+fi
+
+# determine image reference
+case $CMD in
+
+    run_dev)
+        IMG_REF="$LANG_FRAME:dev"
+        ;;
+    
+    run_prod)
+        IMG_REF="$LANG_FRAME:prod"
+        ;;
+
+    test)
+        IMG_REF="$LANG_FRAME:dev"
+        ;;
+
+    lint)
+        IMG_REF="$LANG_FRAME:dev"
+        ;;
+
+    *)
+        echo "Unknown command given; '${CMD}'."
+        exit 1
+
+esac
+
+# check if image exists
+if ! docker image inspect $IMG_REF >/dev/null 2>&1
+    then
+        echo "The required image '$IMG_REF' does not exist."
+        exit 1
+fi
+
+# run image inside container with specified command
+case $CMD in
+
+    run_dev)
+        echo "Checking if api_farm_dev network is available."
+        if ! docker network inspect api_farm_dev >/dev/null 2>&1
+            then
+                echo "The network 'api_farm_dev' does not exist. Creating now..."
+                docker network create api_farm_dev
+        fi
+
+        echo "Running container with run command for image '$IMG_REF'"
+        docker run --rm -dt -p 8080:8080 --network=api_farm_dev --name $SERVICE_NAME -e API_ENV=DEV $IMG_REF run
+        ;;
+        
+    run_prod)
+        echo "Checking if api_farm_prod network is available."
+        if ! docker network inspect api_farm_prod >/dev/null 2>&1
+            then
+                echo "The network 'api_farm_prod' does not exist. Creating now..."
+                docker network create api_farm_prod
+        fi
+
+        echo "Running container with run command for image '$IMG_REF'"
+        docker run --rm -dt -p 8080:8080 --network=api_farm_prod --name $SERVICE_NAME -e API_ENV=PROD $IMG_REF run
+        ;;
+
+    test)
+        echo "Running container with test command for image '$IMG_REF'"
+        docker run --rm $IMG_REF test
+        ;;
+
+    lint)
+        echo "Running container with lint command for image '$IMG_REF'"
+        docker run --rm $IMG_REF lint
+        ;;
+esac


### PR DESCRIPTION
Made to avoid having `build_img.sh` and `run_img.sh` scripts in each api directory.
Some changes will have to be made to the Ruby Sinatra application;
- Removing unneeded `build_img.sh` and `run_img.sh` scripts.
- Update README.md
- Environment variable is now referenced as `API_ENV`, ruby/sinatra checks should use this instead