### PR TITLE
Build Stage in build.sh Script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -56,17 +56,31 @@ if docker image inspect $IMG_REF >/dev/null 2>&1
         docker rmi $IMG_REF
 fi
 
+# check if language/framework has compilation stage
+if [ -f "$LANG_FRAME/.compile" ]
+    then
+        # set target stage for docker build
+        if [ $ENV -eq "prod" ]
+            then
+                $TARGET_FLAG="--target prod-env"
+            else
+                $TARGET_FLAG="--target dev-env"
+        fi
+    else
+        $TARGET_FLAG=""
+fi
+
 # begin docker build
 case $ENV in
 
     dev)
         echo "Building docker image: $LANG_FRAME:dev"
-        docker build -t $IMG_REF $LANG_FRAME
+        docker build $TARGET_FLAG -t $IMG_REF $LANG_FRAME
         ;;
 
     prod)
         echo "Building docker image: $LANG_FRAME:prod"
-        docker build -t $IMG_REF --build-arg env=prod $LANG_FRAME
+        docker build $TARGET_FLAG -t $IMG_REF --build-arg env=prod $LANG_FRAME
         ;;
 
     *)


### PR DESCRIPTION
Included check for languages which are compiled. The check is performed by looking for a `.compile` file within the lang/framework directory (not the neatest solution, but will do for now).

This passes an extra flag to docker files for compiled languages meaning we can (where necessary) perform a build and then copy the binary into a slimmer target. This will help keep the production image much smaller.

Look here for documentation regarding build stages in Docker; https://docs.docker.com/develop/develop-images/multistage-build/