### PR TITLE
Health Script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,8 +109,7 @@ pipeline {
                      try {
                         echo "Running api script; ./scripts/run.sh ${buildPath}"
                         sh "./scripts/run.sh ${buildPath}"
-                        sh "sleep 2"
-                        sh "curl -f http://localhost:8080/ping"
+                        sh "./scripts/health_check.sh"
                     } catch (e) {
                         pullRequest.comment("HEALTH CHECK FAILED ❌. SEE ERROR MESSAGE BELOW:\n${formatMessage(e.message)}")
                         throw e

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# makes a curl request to http://localhost:8080/ping
+# in the event it fails, it retries twice more after a short wait period
+
+# initial wait to give api time to start up
+sleep 1
+
+# set variables
+MAX_RETRY_COUNT=4
+RETRY_COUNT=0
+
+# make curl request
+until curl http://localhost:8080/ping
+    do
+        ((RETRY_COUNT++))
+        echo "Failed attempt #$RETRY_COUNT"
+
+        # if retry count is above or equal maximum; abort with failure
+        if (( $RETRY_COUNT >= $MAX_RETRY_COUNT ))
+            then
+                echo "Failed $MAX_RETRY_COUNT times, aborting."
+                exit 1
+        fi
+
+        sleep 3
+done
+
+# success message
+echo "Successfully pinged api service."
+exit 0


### PR DESCRIPTION
Was still having issues with how long it took apis to start up and accept the curl health check request.
I've added a script which will make the curl request 4 times. Each time, waiting 3 seconds before attempting again.
This will hopefully resolve any issues regarding apis taking too long to kick up before making the curl request.