### PR TITLE
Put Video Game

### DIFF
--- a/go/mux/main.go
+++ b/go/mux/main.go
@@ -35,6 +35,10 @@ func main() {
 		controller.HandlePost(apifarm.NewHTTPRequest(r), apifarm.NewHTTPResponse(&w))
 	}).Methods(http.MethodPost)
 
+	r.HandleFunc("/video_games/{id}", func(w http.ResponseWriter, r *http.Request) {
+		controller.HandlePut(apifarm.NewHTTPRequest(r), apifarm.NewHTTPResponse(&w))
+	}).Methods(http.MethodPut)
+
 	r.HandleFunc("/api_tests/setup", func(w http.ResponseWriter, r *http.Request) {
 		apiTestingController.HandleTestSetup(apifarm.NewHTTPResponse(&w))
 	})

--- a/go/mux/mocks/src/DB.go
+++ b/go/mux/mocks/src/DB.go
@@ -63,3 +63,19 @@ func (_m *DB) GetVideoGame(_a0 uint) *apifarm.VideoGame {
 func (_m *DB) Reset() {
 	_m.Called()
 }
+
+// UpdateVideoGame provides a mock function with given fields: _a0
+func (_m *DB) UpdateVideoGame(_a0 apifarm.VideoGame) *apifarm.VideoGame {
+	ret := _m.Called(_a0)
+
+	var r0 *apifarm.VideoGame
+	if rf, ok := ret.Get(0).(func(apifarm.VideoGame) *apifarm.VideoGame); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*apifarm.VideoGame)
+		}
+	}
+
+	return r0
+}

--- a/go/mux/mocks/src/Service.go
+++ b/go/mux/mocks/src/Service.go
@@ -54,3 +54,17 @@ func (_m *Service) GetAll() apifarm.Query {
 
 	return r0
 }
+
+// Update provides a mock function with given fields: _a0, _a1
+func (_m *Service) Update(_a0 uint, _a1 []byte) apifarm.Query {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 apifarm.Query
+	if rf, ok := ret.Get(0).(func(uint, []byte) apifarm.Query); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Get(0).(apifarm.Query)
+	}
+
+	return r0
+}

--- a/go/mux/src/controller.go
+++ b/go/mux/src/controller.go
@@ -73,7 +73,18 @@ func (c *Controller) HandlePost(req Request, res Response) {
 }
 
 func (c *Controller) HandlePut(req Request, res Response) {
+	strID := req.GetParam("id")
 
+	id, _ := strconv.Atoi(strID)
+
+	body, _ := req.GetBody()
+
+	query := c.s.Update(uint(id), body)
+
+	switch query.Code {
+	case 0:
+		res.OkJSON(query.Result)
+	}
 }
 
 type APITestingController struct {

--- a/go/mux/src/controller.go
+++ b/go/mux/src/controller.go
@@ -98,6 +98,8 @@ func (c *Controller) HandlePut(req Request, res Response) {
 		res.BadRequestText(query.Message)
 	case 404:
 		res.NotFoundText(query.Message)
+	case 500:
+		res.Error(query.Error)
 	}
 }
 

--- a/go/mux/src/controller.go
+++ b/go/mux/src/controller.go
@@ -82,7 +82,12 @@ func (c *Controller) HandlePut(req Request, res Response) {
 		return
 	}
 
-	body, _ := req.GetBody()
+	body, err := req.GetBody()
+
+	if err != nil {
+		res.Error(err)
+		return
+	}
 
 	query := c.s.Update(uint(id), body)
 

--- a/go/mux/src/controller.go
+++ b/go/mux/src/controller.go
@@ -75,7 +75,12 @@ func (c *Controller) HandlePost(req Request, res Response) {
 func (c *Controller) HandlePut(req Request, res Response) {
 	strID := req.GetParam("id")
 
-	id, _ := strconv.Atoi(strID)
+	id, err := strconv.Atoi(strID)
+
+	if err != nil {
+		res.BadRequestText(ParamInvalidID(strID))
+		return
+	}
 
 	body, _ := req.GetBody()
 

--- a/go/mux/src/controller.go
+++ b/go/mux/src/controller.go
@@ -94,11 +94,11 @@ func (c *Controller) HandlePut(req Request, res Response) {
 	switch query.Code {
 	case 0:
 		res.OkJSON(query.Result)
-	case 400:
+	case http.StatusBadRequest:
 		res.BadRequestText(query.Message)
-	case 404:
+	case http.StatusNotFound:
 		res.NotFoundText(query.Message)
-	case 500:
+	case http.StatusInternalServerError:
 		res.Error(query.Error)
 	}
 }

--- a/go/mux/src/controller.go
+++ b/go/mux/src/controller.go
@@ -89,6 +89,8 @@ func (c *Controller) HandlePut(req Request, res Response) {
 	switch query.Code {
 	case 0:
 		res.OkJSON(query.Result)
+	case 400:
+		res.BadRequestText(query.Message)
 	}
 }
 

--- a/go/mux/src/controller.go
+++ b/go/mux/src/controller.go
@@ -91,6 +91,8 @@ func (c *Controller) HandlePut(req Request, res Response) {
 		res.OkJSON(query.Result)
 	case 400:
 		res.BadRequestText(query.Message)
+	case 404:
+		res.NotFoundText(query.Message)
 	}
 }
 

--- a/go/mux/src/controller.go
+++ b/go/mux/src/controller.go
@@ -72,6 +72,10 @@ func (c *Controller) HandlePost(req Request, res Response) {
 	}
 }
 
+func (c *Controller) HandlePut(req Request, res Response) {
+
+}
+
 type APITestingController struct {
 	dl DataLoader
 }

--- a/go/mux/src/controller_test.go
+++ b/go/mux/src/controller_test.go
@@ -326,6 +326,32 @@ func TestHandlePut400FromQuery(t *testing.T) {
 	mockResponse.AssertExpectations(t)
 }
 
+func TestHandlePut404(t *testing.T) {
+	// Arrange
+	mockService := new(mocks.Service)
+	mockRequest := new(mocks.Request)
+	mockResponse := new(mocks.Response)
+
+	subject := apifarm.NewController(mockService)
+
+	body := []byte{20, 18, 48}
+	queryMessage := "VIDEO GAME NOT FOUND"
+	query := apifarm.Query{Message: queryMessage, Code: uint(404)}
+
+	mockRequest.On("GetParam", "id").Return("99")
+	mockRequest.On("GetBody").Return(body, nil)
+	mockService.On("Update", uint(99), body).Return(query)
+	mockResponse.On("NotFoundText", queryMessage)
+
+	// Act
+	subject.HandlePut(mockRequest, mockResponse)
+
+	// Assert
+	mockService.AssertExpectations(t)
+	mockRequest.AssertExpectations(t)
+	mockResponse.AssertExpectations(t)
+}
+
 func TestHandleTestSetup200(t *testing.T) {
 	// Arrange
 	mockDataLoader := new(mocks.DataLoader)

--- a/go/mux/src/controller_test.go
+++ b/go/mux/src/controller_test.go
@@ -352,6 +352,29 @@ func TestHandlePut404(t *testing.T) {
 	mockResponse.AssertExpectations(t)
 }
 
+func TestHandlePut500BodyReadFailure(t *testing.T) {
+	// Arrange
+	mockService := new(mocks.Service)
+	mockRequest := new(mocks.Request)
+	mockResponse := new(mocks.Response)
+
+	subject := apifarm.NewController(mockService)
+
+	err := errors.New("body read failed")
+
+	mockRequest.On("GetParam", "id").Return("5")
+	mockRequest.On("GetBody").Return(nil, err)
+	mockResponse.On("Error", err)
+
+	// Act
+	subject.HandlePut(mockRequest, mockResponse)
+
+	// Assert
+	mockService.AssertExpectations(t)
+	mockRequest.AssertExpectations(t)
+	mockResponse.AssertExpectations(t)
+}
+
 func TestHandleTestSetup200(t *testing.T) {
 	// Arrange
 	mockDataLoader := new(mocks.DataLoader)

--- a/go/mux/src/controller_test.go
+++ b/go/mux/src/controller_test.go
@@ -300,6 +300,32 @@ func TestHandlePut400InvalidID(t *testing.T) {
 	mockResponse.AssertExpectations(t)
 }
 
+func TestHandlePut400FromQuery(t *testing.T) {
+	// Arrange
+	mockService := new(mocks.Service)
+	mockRequest := new(mocks.Request)
+	mockResponse := new(mocks.Response)
+
+	subject := apifarm.NewController(mockService)
+
+	body := []byte{20, 18, 48}
+	queryMessage := "INVALID VIDEO GAME"
+	query := apifarm.Query{Message: queryMessage, Code: uint(400)}
+
+	mockRequest.On("GetParam", "id").Return("5")
+	mockRequest.On("GetBody").Return(body, nil)
+	mockService.On("Update", uint(5), body).Return(query)
+	mockResponse.On("BadRequestText", queryMessage)
+
+	// Act
+	subject.HandlePut(mockRequest, mockResponse)
+
+	// Assert
+	mockService.AssertExpectations(t)
+	mockRequest.AssertExpectations(t)
+	mockResponse.AssertExpectations(t)
+}
+
 func TestHandleTestSetup200(t *testing.T) {
 	// Arrange
 	mockDataLoader := new(mocks.DataLoader)

--- a/go/mux/src/controller_test.go
+++ b/go/mux/src/controller_test.go
@@ -278,6 +278,28 @@ func TestHandlePut200(t *testing.T) {
 	mockResponse.AssertExpectations(t)
 }
 
+func TestHandlePut400InvalidID(t *testing.T) {
+	// Arrange
+	mockService := new(mocks.Service)
+	mockRequest := new(mocks.Request)
+	mockResponse := new(mocks.Response)
+
+	subject := apifarm.NewController(mockService)
+
+	invalidID := "invalid!"
+
+	mockRequest.On("GetParam", "id").Return(invalidID)
+	mockResponse.On("BadRequestText", apifarm.ParamInvalidID(invalidID))
+
+	// Act
+	subject.HandlePut(mockRequest, mockResponse)
+
+	// Assert
+	mockService.AssertExpectations(t)
+	mockRequest.AssertExpectations(t)
+	mockResponse.AssertExpectations(t)
+}
+
 func TestHandleTestSetup200(t *testing.T) {
 	// Arrange
 	mockDataLoader := new(mocks.DataLoader)

--- a/go/mux/src/controller_test.go
+++ b/go/mux/src/controller_test.go
@@ -375,6 +375,32 @@ func TestHandlePut500BodyReadFailure(t *testing.T) {
 	mockResponse.AssertExpectations(t)
 }
 
+func TestHandlePut500ServiceFailure(t *testing.T) {
+	// Arrange
+	mockService := new(mocks.Service)
+	mockRequest := new(mocks.Request)
+	mockResponse := new(mocks.Response)
+
+	subject := apifarm.NewController(mockService)
+
+	body := []byte{20, 18, 48}
+	err := errors.New("query failed")
+	query := apifarm.Query{Code: uint(500), Error: err}
+
+	mockRequest.On("GetParam", "id").Return("5")
+	mockRequest.On("GetBody").Return(body, nil)
+	mockService.On("Update", uint(5), body).Return(query)
+	mockResponse.On("Error", err)
+
+	// Act
+	subject.HandlePut(mockRequest, mockResponse)
+
+	// Assert
+	mockService.AssertExpectations(t)
+	mockRequest.AssertExpectations(t)
+	mockResponse.AssertExpectations(t)
+}
+
 func TestHandleTestSetup200(t *testing.T) {
 	// Arrange
 	mockDataLoader := new(mocks.DataLoader)

--- a/go/mux/src/controller_test.go
+++ b/go/mux/src/controller_test.go
@@ -266,7 +266,7 @@ func TestHandlePut200(t *testing.T) {
 
 	mockRequest.On("GetParam", "id").Return("5")
 	mockRequest.On("GetBody").Return(body, nil)
-	mockService.On("Update", body).Return(query)
+	mockService.On("Update", uint(5), body).Return(query)
 	mockResponse.On("OkJSON", result)
 
 	// Act

--- a/go/mux/src/controller_test.go
+++ b/go/mux/src/controller_test.go
@@ -252,6 +252,32 @@ func TestHandlePost500ServiceFailure(t *testing.T) {
 	mockResponse.AssertExpectations(t)
 }
 
+func TestHandlePut200(t *testing.T) {
+	// Arrange
+	mockService := new(mocks.Service)
+	mockRequest := new(mocks.Request)
+	mockResponse := new(mocks.Response)
+
+	subject := apifarm.NewController(mockService)
+
+	body := []byte{20, 18, 48}
+	result := []byte{90, 92, 56}
+	query := apifarm.Query{Result: result}
+
+	mockRequest.On("GetParam", "id").Return("5")
+	mockRequest.On("GetBody").Return(body, nil)
+	mockService.On("Update", body).Return(query)
+	mockResponse.On("OkJSON", result)
+
+	// Act
+	subject.HandlePut(mockRequest, mockResponse)
+
+	// Assert
+	mockService.AssertExpectations(t)
+	mockRequest.AssertExpectations(t)
+	mockResponse.AssertExpectations(t)
+}
+
 func TestHandleTestSetup200(t *testing.T) {
 	// Arrange
 	mockDataLoader := new(mocks.DataLoader)

--- a/go/mux/src/db.go
+++ b/go/mux/src/db.go
@@ -48,8 +48,6 @@ func (db *InMemory) AddVideoGame(vg VideoGame) VideoGame {
 	db.idCounter++
 	vg.ID = db.idCounter
 
-	setEmptySlices(&vg)
-
 	vgs := append(*db.videoGames, vg)
 	db.videoGames = &vgs
 	return vg
@@ -69,34 +67,4 @@ func (db *InMemory) UpdateVideoGame(uvg VideoGame) *VideoGame {
 func (db *InMemory) Reset() {
 	db.idCounter = 0
 	db.videoGames = &[]VideoGame{}
-}
-
-func setEmptySlices(vg *VideoGame) {
-	if vg.Developers == nil {
-		vg.Developers = []string{}
-	}
-	if vg.Publishers == nil {
-		vg.Publishers = []string{}
-	}
-	if vg.Directors == nil {
-		vg.Directors = []string{}
-	}
-	if vg.Producers == nil {
-		vg.Producers = []string{}
-	}
-	if vg.Designers == nil {
-		vg.Designers = []string{}
-	}
-	if vg.Programmers == nil {
-		vg.Programmers = []string{}
-	}
-	if vg.Artists == nil {
-		vg.Artists = []string{}
-	}
-	if vg.Composers == nil {
-		vg.Composers = []string{}
-	}
-	if vg.Platforms == nil {
-		vg.Platforms = []string{}
-	}
 }

--- a/go/mux/src/db.go
+++ b/go/mux/src/db.go
@@ -55,6 +55,10 @@ func (db *InMemory) AddVideoGame(vg VideoGame) VideoGame {
 	return vg
 }
 
+func (db *InMemory) UpdateVideoGame(vg VideoGame) VideoGame {
+	return VideoGame{}
+}
+
 func (db *InMemory) Reset() {
 	db.idCounter = 0
 	db.videoGames = &[]VideoGame{}

--- a/go/mux/src/db.go
+++ b/go/mux/src/db.go
@@ -63,7 +63,7 @@ func (db *InMemory) UpdateVideoGame(uvg VideoGame) *VideoGame {
 		}
 	}
 
-	return &VideoGame{}
+	return nil
 }
 
 func (db *InMemory) Reset() {

--- a/go/mux/src/db.go
+++ b/go/mux/src/db.go
@@ -55,8 +55,15 @@ func (db *InMemory) AddVideoGame(vg VideoGame) VideoGame {
 	return vg
 }
 
-func (db *InMemory) UpdateVideoGame(vg VideoGame) VideoGame {
-	return VideoGame{}
+func (db *InMemory) UpdateVideoGame(uvg VideoGame) *VideoGame {
+	for i, vg := range *db.videoGames {
+		if vg.ID == uvg.ID {
+			(*db.videoGames)[i] = uvg
+			return &uvg
+		}
+	}
+
+	return &VideoGame{}
 }
 
 func (db *InMemory) Reset() {

--- a/go/mux/src/db.go
+++ b/go/mux/src/db.go
@@ -4,6 +4,7 @@ type DB interface {
 	GetVideoGame(uint) *VideoGame
 	GetAllVideoGames() []VideoGame
 	AddVideoGame(VideoGame) VideoGame
+	UpdateVideoGame(VideoGame) *VideoGame
 	Reset()
 }
 

--- a/go/mux/src/db_test.go
+++ b/go/mux/src/db_test.go
@@ -97,6 +97,28 @@ func TestInMemoryAddVideoGameIncrementsAndSetsId(t *testing.T) {
 	assert.Len(t, **videoGames, 3)
 }
 
+func TestInMemoryUpdateVideoGame(t *testing.T) {
+	// Arrange
+	subject, videoGames := apifarm.NewInMemoryForTests()
+
+	videoGameToUpdate := apifarm.VideoGame{ID: 2, Name: "TO BE UPDATED"}
+	includingVideoGames := []apifarm.VideoGame{
+		{ID: 1, Name: "GAME 1"},
+		videoGameToUpdate,
+		{ID: 3, Name: "GAME 3"},
+	}
+	*videoGames = &includingVideoGames
+	expected := apifarm.VideoGame{ID: 2, Name: "HAS BEEN UPDATED"}
+
+	// Act
+	got := subject.UpdateVideoGame(expected)
+
+	// Assert
+	assert.Equal(t, expected, got)
+	assert.NotContains(t, **videoGames, videoGameToUpdate)
+	assert.Contains(t, **videoGames, expected)
+}
+
 func TestInMemoryReset(t *testing.T) {
 	// Arrange
 	subject, videoGames := apifarm.NewInMemoryForTests()

--- a/go/mux/src/db_test.go
+++ b/go/mux/src/db_test.go
@@ -119,6 +119,17 @@ func TestInMemoryUpdateVideoGame(t *testing.T) {
 	assert.Contains(t, **videoGames, expected)
 }
 
+func TestInMemoryUpdateVideoGameReturnsNil(t *testing.T) {
+	// Arrange
+	subject, _ := apifarm.NewInMemoryForTests()
+
+	// Act
+	got := subject.UpdateVideoGame(apifarm.VideoGame{})
+
+	// Assert
+	assert.Nil(t, got)
+}
+
 func TestInMemoryReset(t *testing.T) {
 	// Arrange
 	subject, videoGames := apifarm.NewInMemoryForTests()

--- a/go/mux/src/db_test.go
+++ b/go/mux/src/db_test.go
@@ -114,7 +114,7 @@ func TestInMemoryUpdateVideoGame(t *testing.T) {
 	got := subject.UpdateVideoGame(expected)
 
 	// Assert
-	assert.Equal(t, expected, got)
+	assert.Equal(t, expected, *got)
 	assert.NotContains(t, **videoGames, videoGameToUpdate)
 	assert.Contains(t, **videoGames, expected)
 }

--- a/go/mux/src/db_test.go
+++ b/go/mux/src/db_test.go
@@ -55,21 +55,11 @@ func TestInMemoryAddVideoGame(t *testing.T) {
 
 	name := "The Great Gamesby"
 	dateReleased := apifarm.CustomTime{}
-	platforms := []string{"A", "B"}
-	videoGame := apifarm.VideoGame{Name: name, Platforms: platforms, DateReleased: dateReleased}
+	videoGame := apifarm.VideoGame{Name: name, DateReleased: dateReleased}
 	expected := apifarm.VideoGame{
-		uint(1),
-		name,
-		[]string{},
-		[]string{},
-		[]string{},
-		[]string{},
-		[]string{},
-		[]string{},
-		[]string{},
-		[]string{},
-		platforms,
-		dateReleased,
+		ID:           uint(1),
+		Name:         name,
+		DateReleased: dateReleased,
 	}
 
 	// Act

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -114,6 +114,8 @@ func (s *VideoGameService) Update(id uint, data []byte) Query {
 		case *time.ParseError:
 			msg := VideoGameInvalidDate(t.Value)
 			return s.qf.BuildMessage(msg, http.StatusBadRequest)
+		default:
+			return s.qf.BuildMessage(InvalidJSON, http.StatusBadRequest)
 		}
 	}
 

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -105,7 +105,15 @@ func (s *VideoGameService) Update(id uint, data []byte) Query {
 		return s.qf.BuildMessage(VideoGameNotFound(id), http.StatusNotFound)
 	}
 
-	vgu, _ := s.json.DeserializeVideoGame(data)
+	vgu, err := s.json.DeserializeVideoGame(data)
+
+	if err != nil {
+		switch t := err.(type) {
+		case *time.ParseError:
+			msg := VideoGameInvalidDate(t.Value)
+			return s.qf.BuildMessage(msg, http.StatusBadRequest)
+		}
+	}
 
 	uvg := updateVideoGameFields(*vg, *vgu)
 

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -101,6 +101,10 @@ func (s *VideoGameService) Add(data []byte) Query {
 func (s *VideoGameService) Update(id uint, data []byte) Query {
 	vg := s.db.GetVideoGame(id)
 
+	if vg == nil {
+		return s.qf.BuildMessage(VideoGameNotFound(id), http.StatusNotFound)
+	}
+
 	vgu, _ := s.json.DeserializeVideoGame(data)
 
 	uvg := updateVideoGameFields(*vg, *vgu)

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -9,6 +9,7 @@ type Service interface {
 	Get(uint) Query
 	GetAll() Query
 	Add([]byte) Query
+	Update(uint, []byte) Query
 }
 
 type VideoGameService struct {

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -109,6 +109,8 @@ func (s *VideoGameService) Update(id uint, data []byte) Query {
 
 	if err != nil {
 		switch t := err.(type) {
+		case *InvalidAttributeError:
+			return s.qf.BuildMessage(t.Error(), http.StatusBadRequest)
 		case *time.ParseError:
 			msg := VideoGameInvalidDate(t.Value)
 			return s.qf.BuildMessage(msg, http.StatusBadRequest)

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -85,6 +85,8 @@ func (s *VideoGameService) Add(data []byte) Query {
 		return s.qf.BuildMessage(VideoGameDateRequired, http.StatusBadRequest)
 	}
 
+	setEmptySlices(vg)
+
 	svg := s.db.AddVideoGame(*vg)
 
 	b, err := s.json.Serialize(&svg)
@@ -94,4 +96,34 @@ func (s *VideoGameService) Add(data []byte) Query {
 	}
 
 	return s.qf.BuildResult(b, uint(0))
+}
+
+func setEmptySlices(vg *VideoGame) {
+	if vg.Developers == nil {
+		vg.Developers = []string{}
+	}
+	if vg.Publishers == nil {
+		vg.Publishers = []string{}
+	}
+	if vg.Directors == nil {
+		vg.Directors = []string{}
+	}
+	if vg.Producers == nil {
+		vg.Producers = []string{}
+	}
+	if vg.Designers == nil {
+		vg.Designers = []string{}
+	}
+	if vg.Programmers == nil {
+		vg.Programmers = []string{}
+	}
+	if vg.Artists == nil {
+		vg.Artists = []string{}
+	}
+	if vg.Composers == nil {
+		vg.Composers = []string{}
+	}
+	if vg.Platforms == nil {
+		vg.Platforms = []string{}
+	}
 }

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -98,6 +98,10 @@ func (s *VideoGameService) Add(data []byte) Query {
 	return s.qf.BuildResult(b, uint(0))
 }
 
+func (s *VideoGameService) Update(id uint, data []byte) Query {
+	return Query{}
+}
+
 func setEmptySlices(vg *VideoGame) {
 	if vg.Developers == nil {
 		vg.Developers = []string{}

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -99,7 +99,17 @@ func (s *VideoGameService) Add(data []byte) Query {
 }
 
 func (s *VideoGameService) Update(id uint, data []byte) Query {
-	return Query{}
+	vg := s.db.GetVideoGame(id)
+
+	vgu, _ := s.json.DeserializeVideoGame(data)
+
+	uvg := updateVideoGameFields(*vg, *vgu)
+
+	suvg := s.db.UpdateVideoGame(uvg)
+
+	b, _ := s.json.Serialize(suvg)
+
+	return s.qf.BuildResult(b, uint(0))
 }
 
 func setEmptySlices(vg *VideoGame) {
@@ -130,4 +140,77 @@ func setEmptySlices(vg *VideoGame) {
 	if vg.Platforms == nil {
 		vg.Platforms = []string{}
 	}
+}
+
+func updateVideoGameFields(vg, vgu VideoGame) VideoGame {
+	uvg := VideoGame{ID: vg.ID}
+
+	if len(vgu.Name) > 0 {
+		uvg.Name = vgu.Name
+	} else {
+		uvg.Name = vg.Name
+	}
+
+	if vgu.Developers != nil {
+		uvg.Developers = vgu.Developers
+	} else {
+		uvg.Developers = vg.Developers
+	}
+
+	if vgu.Publishers != nil {
+		uvg.Publishers = vgu.Publishers
+	} else {
+		uvg.Publishers = vg.Publishers
+	}
+
+	if vgu.Directors != nil {
+		uvg.Directors = vgu.Directors
+	} else {
+		uvg.Directors = vg.Directors
+	}
+
+	if vgu.Producers != nil {
+		uvg.Producers = vgu.Producers
+	} else {
+		uvg.Producers = vg.Producers
+	}
+
+	if vgu.Designers != nil {
+		uvg.Designers = vgu.Designers
+	} else {
+		uvg.Designers = vg.Designers
+	}
+
+	if vgu.Programmers != nil {
+		uvg.Programmers = vgu.Programmers
+	} else {
+		uvg.Programmers = vg.Programmers
+	}
+
+	if vgu.Artists != nil {
+		uvg.Artists = vgu.Artists
+	} else {
+		uvg.Artists = vg.Artists
+	}
+
+	if vgu.Composers != nil {
+		uvg.Composers = vgu.Composers
+	} else {
+		uvg.Composers = vg.Composers
+	}
+
+	if vgu.Platforms != nil {
+		uvg.Platforms = vgu.Platforms
+	} else {
+		uvg.Platforms = vg.Platforms
+	}
+
+	dt := time.Time{}
+	if vgu.DateReleased.Time != dt {
+		uvg.DateReleased = vgu.DateReleased
+	} else {
+		uvg.DateReleased = vg.DateReleased
+	}
+
+	return uvg
 }

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -171,61 +171,51 @@ func updateVideoGameFields(vg, vgu VideoGame) VideoGame {
 	} else {
 		uvg.Name = vg.Name
 	}
-
 	if vgu.Developers != nil {
 		uvg.Developers = vgu.Developers
 	} else {
 		uvg.Developers = vg.Developers
 	}
-
 	if vgu.Publishers != nil {
 		uvg.Publishers = vgu.Publishers
 	} else {
 		uvg.Publishers = vg.Publishers
 	}
-
 	if vgu.Directors != nil {
 		uvg.Directors = vgu.Directors
 	} else {
 		uvg.Directors = vg.Directors
 	}
-
 	if vgu.Producers != nil {
 		uvg.Producers = vgu.Producers
 	} else {
 		uvg.Producers = vg.Producers
 	}
-
 	if vgu.Designers != nil {
 		uvg.Designers = vgu.Designers
 	} else {
 		uvg.Designers = vg.Designers
 	}
-
 	if vgu.Programmers != nil {
 		uvg.Programmers = vgu.Programmers
 	} else {
 		uvg.Programmers = vg.Programmers
 	}
-
 	if vgu.Artists != nil {
 		uvg.Artists = vgu.Artists
 	} else {
 		uvg.Artists = vg.Artists
 	}
-
 	if vgu.Composers != nil {
 		uvg.Composers = vgu.Composers
 	} else {
 		uvg.Composers = vg.Composers
 	}
-
 	if vgu.Platforms != nil {
 		uvg.Platforms = vgu.Platforms
 	} else {
 		uvg.Platforms = vg.Platforms
 	}
-
 	dt := time.Time{}
 	if vgu.DateReleased.Time != dt {
 		uvg.DateReleased = vgu.DateReleased

--- a/go/mux/src/service.go
+++ b/go/mux/src/service.go
@@ -123,7 +123,11 @@ func (s *VideoGameService) Update(id uint, data []byte) Query {
 
 	suvg := s.db.UpdateVideoGame(uvg)
 
-	b, _ := s.json.Serialize(suvg)
+	b, err := s.json.Serialize(suvg)
+
+	if err != nil {
+		return s.qf.Error(err)
+	}
 
 	return s.qf.BuildResult(b, uint(0))
 }

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -375,3 +375,66 @@ func TestVideoGameServiceAddSerializationFailure(t *testing.T) {
 	mockJSON.AssertExpectations(t)
 	mockQueryFactory.AssertExpectations(t)
 }
+
+func TestVideoGameServiceUpdateSuccessful(t *testing.T) {
+	// Arrange
+	mockStorage := new(mocks.DB)
+	mockJSON := new(mocks.DataUtils)
+	mockQueryFactory := new(mocks.QueryFactory)
+
+	subject := apifarm.NewVideoGameServiceWithUtils(mockStorage, mockJSON, mockQueryFactory)
+
+	id := uint(5)
+	reqData := []byte{13, 34, 22}
+	videoGameToUpdateWith := apifarm.VideoGame{
+		Name:       "Updated Name",
+		Developers: []string{"A", "B"},
+		Designers:  []string{"A", "B", "C"},
+		Artists:    []string{"A", "B", "C"},
+	}
+	videoGameToUpdate := apifarm.VideoGame{
+		uint(5),
+		"Old Name",
+		[]string{"1", "2"},
+		[]string{"1"},
+		[]string{"1", "2"},
+		[]string{"1", "2", "3"},
+		[]string{"1", "2"},
+		[]string{"1", "2", "3"},
+		[]string{"1", "2"},
+		[]string{"1", "2"},
+		[]string{"1", "2", "3"},
+		apifarm.CustomTime{Time: time.Now()},
+	}
+	updatedVideoGame := apifarm.VideoGame{
+		videoGameToUpdate.ID,
+		videoGameToUpdateWith.Name,
+		videoGameToUpdateWith.Developers,
+		videoGameToUpdate.Publishers,
+		videoGameToUpdate.Directors,
+		videoGameToUpdate.Producers,
+		videoGameToUpdateWith.Designers,
+		videoGameToUpdate.Programmers,
+		videoGameToUpdateWith.Artists,
+		videoGameToUpdate.Composers,
+		videoGameToUpdate.Platforms,
+		videoGameToUpdate.DateReleased,
+	}
+	serializedUpdatedVideoGame := []byte{12, 21, 35}
+	expectedQuery := apifarm.Query{}
+
+	mockJSON.On("DeserializeVideoGame", reqData).Return(&videoGameToUpdateWith, nil)
+	mockStorage.On("GetVideoGame", id).Return(&videoGameToUpdate)
+	mockStorage.On("UpdateVideoGame", updatedVideoGame).Return(&updatedVideoGame)
+	mockJSON.On("Serialize", updatedVideoGame).Return(serializedUpdatedVideoGame)
+	mockQueryFactory.On("BuildResult", serializedUpdatedVideoGame, uint(0)).Return(expectedQuery)
+
+	// Act
+	actualQuery := subject.Update(id, reqData)
+
+	// Assert
+	assert.Equal(t, expectedQuery, actualQuery)
+	mockStorage.AssertExpectations(t)
+	mockJSON.AssertExpectations(t)
+	mockQueryFactory.AssertExpectations(t)
+}

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -519,3 +519,31 @@ func TestVideoGameServiceUpdateInvalidDateFailure(t *testing.T) {
 	mockJSON.AssertExpectations(t)
 	mockQueryFactory.AssertExpectations(t)
 }
+
+func TestVideoGameServiceUpdateDeserializationFailure(t *testing.T) {
+	// Arrange
+	mockStorage := new(mocks.DB)
+	mockJSON := new(mocks.DataUtils)
+	mockQueryFactory := new(mocks.QueryFactory)
+
+	subject := apifarm.NewVideoGameServiceWithUtils(mockStorage, mockJSON, mockQueryFactory)
+
+	id := uint(5)
+	reqData := []byte{13, 34, 22}
+	videoGameToUpdate := apifarm.VideoGame{}
+	err := errors.New("failed to deserialize")
+	expectedQuery := apifarm.Query{}
+
+	mockStorage.On("GetVideoGame", id).Return(&videoGameToUpdate)
+	mockJSON.On("DeserializeVideoGame", reqData).Return(nil, err)
+	mockQueryFactory.On("BuildMessage", apifarm.InvalidJSON, uint(400)).Return(expectedQuery)
+
+	// Act
+	actualQuery := subject.Update(id, reqData)
+
+	// Assert
+	assert.Equal(t, expectedQuery, actualQuery)
+	mockStorage.AssertExpectations(t)
+	mockJSON.AssertExpectations(t)
+	mockQueryFactory.AssertExpectations(t)
+}

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -451,7 +451,7 @@ func TestVideoGameServiceUpdateNotFound(t *testing.T) {
 	expectedQuery := apifarm.Query{}
 
 	mockStorage.On("GetVideoGame", id).Return(nil)
-	mockQueryFactory.On("BuildResult", apifarm.VideoGameNotFound(id), uint(404)).Return(expectedQuery)
+	mockQueryFactory.On("BuildMessage", apifarm.VideoGameNotFound(id), uint(404)).Return(expectedQuery)
 
 	// Act
 	actualQuery := subject.Update(id, []byte{})

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -462,6 +462,7 @@ func TestVideoGameServiceUpdateNotFound(t *testing.T) {
 	mockQueryFactory.AssertExpectations(t)
 }
 
+//nolint: dupl
 func TestVideoGameServiceUpdateInvalidAttributeFailure(t *testing.T) {
 	// Arrange
 	mockStorage := new(mocks.DB)
@@ -472,14 +473,14 @@ func TestVideoGameServiceUpdateInvalidAttributeFailure(t *testing.T) {
 
 	id := uint(5)
 	reqData := []byte{13, 34, 22}
-	invalidAttribute := "testers"
-	videoGameToUpdate := apifarm.VideoGame{}
-	err := &apifarm.InvalidAttributeError{Attribute: invalidAttribute}
+	attribute := "testers"
+	err := &apifarm.InvalidAttributeError{Attribute: attribute}
 	expectedQuery := apifarm.Query{}
 
-	mockStorage.On("GetVideoGame", id).Return(&videoGameToUpdate)
+	mockStorage.On("GetVideoGame", id).Return(apifarm.VideoGame{})
 	mockJSON.On("DeserializeVideoGame", reqData).Return(nil, err)
-	mockQueryFactory.On("BuildMessage", apifarm.VideoGameInvalidAttribute(invalidAttribute), uint(400)).Return(expectedQuery)
+	mockQueryFactory.On("BuildMessage", apifarm.VideoGameInvalidAttribute(attribute),
+		uint(400)).Return(expectedQuery)
 
 	// Act
 	actualQuery := subject.Update(id, reqData)
@@ -491,6 +492,7 @@ func TestVideoGameServiceUpdateInvalidAttributeFailure(t *testing.T) {
 	mockQueryFactory.AssertExpectations(t)
 }
 
+//nolint: dupl
 func TestVideoGameServiceUpdateInvalidDateFailure(t *testing.T) {
 	// Arrange
 	mockStorage := new(mocks.DB)
@@ -502,13 +504,13 @@ func TestVideoGameServiceUpdateInvalidDateFailure(t *testing.T) {
 	id := uint(5)
 	reqData := []byte{13, 34, 22}
 	invalidDate := "2010/08/26"
-	videoGameToUpdate := apifarm.VideoGame{}
 	err := &time.ParseError{Value: invalidDate}
 	expectedQuery := apifarm.Query{}
 
-	mockStorage.On("GetVideoGame", id).Return(&videoGameToUpdate)
+	mockStorage.On("GetVideoGame", id).Return(apifarm.VideoGame{})
 	mockJSON.On("DeserializeVideoGame", reqData).Return(nil, err)
-	mockQueryFactory.On("BuildMessage", apifarm.VideoGameInvalidDate(invalidDate), uint(400)).Return(expectedQuery)
+	mockQueryFactory.On("BuildMessage", apifarm.VideoGameInvalidDate(invalidDate),
+		uint(400)).Return(expectedQuery)
 
 	// Act
 	actualQuery := subject.Update(id, reqData)

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -438,3 +438,26 @@ func TestVideoGameServiceUpdateSuccessful(t *testing.T) {
 	mockJSON.AssertExpectations(t)
 	mockQueryFactory.AssertExpectations(t)
 }
+
+func TestVideoGameServiceUpdateNotFound(t *testing.T) {
+	// Arrange
+	mockStorage := new(mocks.DB)
+	mockJSON := new(mocks.DataUtils)
+	mockQueryFactory := new(mocks.QueryFactory)
+
+	subject := apifarm.NewVideoGameServiceWithUtils(mockStorage, mockJSON, mockQueryFactory)
+
+	id := uint(5)
+	expectedQuery := apifarm.Query{}
+
+	mockStorage.On("GetVideoGame", id).Return(nil)
+	mockQueryFactory.On("BuildResult", apifarm.VideoGameNotFound(id), uint(404)).Return(expectedQuery)
+
+	// Act
+	actualQuery := subject.Update(id, []byte{})
+
+	// Assert
+	assert.Equal(t, expectedQuery, actualQuery)
+	mockStorage.AssertExpectations(t)
+	mockQueryFactory.AssertExpectations(t)
+}

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -477,7 +477,7 @@ func TestVideoGameServiceUpdateInvalidAttributeFailure(t *testing.T) {
 	err := &apifarm.InvalidAttributeError{Attribute: attribute}
 	expectedQuery := apifarm.Query{}
 
-	mockStorage.On("GetVideoGame", id).Return(apifarm.VideoGame{})
+	mockStorage.On("GetVideoGame", id).Return(&apifarm.VideoGame{})
 	mockJSON.On("DeserializeVideoGame", reqData).Return(nil, err)
 	mockQueryFactory.On("BuildMessage", apifarm.VideoGameInvalidAttribute(attribute),
 		uint(400)).Return(expectedQuery)
@@ -507,7 +507,7 @@ func TestVideoGameServiceUpdateInvalidDateFailure(t *testing.T) {
 	err := &time.ParseError{Value: invalidDate}
 	expectedQuery := apifarm.Query{}
 
-	mockStorage.On("GetVideoGame", id).Return(apifarm.VideoGame{})
+	mockStorage.On("GetVideoGame", id).Return(&apifarm.VideoGame{})
 	mockJSON.On("DeserializeVideoGame", reqData).Return(nil, err)
 	mockQueryFactory.On("BuildMessage", apifarm.VideoGameInvalidDate(invalidDate),
 		uint(400)).Return(expectedQuery)

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -461,3 +461,32 @@ func TestVideoGameServiceUpdateNotFound(t *testing.T) {
 	mockStorage.AssertExpectations(t)
 	mockQueryFactory.AssertExpectations(t)
 }
+
+func TestVideoGameServiceUpdateInvalidDateFailure(t *testing.T) {
+	// Arrange
+	mockStorage := new(mocks.DB)
+	mockJSON := new(mocks.DataUtils)
+	mockQueryFactory := new(mocks.QueryFactory)
+
+	subject := apifarm.NewVideoGameServiceWithUtils(mockStorage, mockJSON, mockQueryFactory)
+
+	id := uint(5)
+	reqData := []byte{13, 34, 22}
+	invalidDate := "2010/08/26"
+	videoGameToUpdate := apifarm.VideoGame{}
+	err := time.ParseError{Value: invalidDate}
+	expectedQuery := apifarm.Query{}
+
+	mockStorage.On("GetVideoGame", id).Return(&videoGameToUpdate)
+	mockJSON.On("DeserializeVideoGame", reqData).Return(nil, err)
+	mockQueryFactory.On("BuildMessage", apifarm.VideoGameInvalidDate(invalidDate), uint(400)).Return(expectedQuery)
+
+	// Act
+	actualQuery := subject.Update(id, reqData)
+
+	// Assert
+	assert.Equal(t, expectedQuery, actualQuery)
+	mockStorage.AssertExpectations(t)
+	mockJSON.AssertExpectations(t)
+	mockQueryFactory.AssertExpectations(t)
+}

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -474,7 +474,7 @@ func TestVideoGameServiceUpdateInvalidDateFailure(t *testing.T) {
 	reqData := []byte{13, 34, 22}
 	invalidDate := "2010/08/26"
 	videoGameToUpdate := apifarm.VideoGame{}
-	err := time.ParseError{Value: invalidDate}
+	err := &time.ParseError{Value: invalidDate}
 	expectedQuery := apifarm.Query{}
 
 	mockStorage.On("GetVideoGame", id).Return(&videoGameToUpdate)

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -155,20 +155,40 @@ func TestVideoGameServiceAddSuccessful(t *testing.T) {
 	subject := apifarm.NewVideoGameServiceWithUtils(mockStorage, mockJSON, mockQueryFactory)
 
 	reqData := []byte{20, 18, 24}
+	videoGameName := "Lady's Quest 3"
+	videoGameDevelopers := []string{"A", "B"}
+	videoGameProducers := []string{"A"}
+	videoGameDateReleased := apifarm.CustomTime{time.Now()}
 	videoGame := apifarm.VideoGame{
-		Name:         "Lady's Quest 3",
-		DateReleased: apifarm.CustomTime{time.Now()},
+		Name:         videoGameName,
+		Developers:   videoGameDevelopers,
+		Producers:    videoGameProducers,
+		DateReleased: videoGameDateReleased,
+	}
+	defaultedVideoGame := apifarm.VideoGame{
+		uint(0),
+		videoGameName,
+		videoGameDevelopers,
+		[]string{},
+		[]string{},
+		videoGameProducers,
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		videoGameDateReleased,
 	}
 	storedVideoGame := apifarm.VideoGame{
 		ID:           1,
-		Name:         "Lady's Quest 3",
-		DateReleased: apifarm.CustomTime{time.Now()},
+		Name:         videoGameName,
+		DateReleased: videoGameDateReleased,
 	}
 	serializedVideoGame := []byte{23, 19, 18}
 	expectedQuery := apifarm.Query{}
 
 	mockJSON.On("DeserializeVideoGame", reqData).Return(&videoGame, nil)
-	mockStorage.On("AddVideoGame", videoGame).Return(storedVideoGame)
+	mockStorage.On("AddVideoGame", defaultedVideoGame).Return(storedVideoGame)
 	mockJSON.On("Serialize", &storedVideoGame).Return(serializedVideoGame, nil)
 	mockQueryFactory.On("BuildResult", serializedVideoGame, uint(0)).Return(expectedQuery)
 
@@ -320,8 +340,18 @@ func TestVideoGameServiceAddSerializationFailure(t *testing.T) {
 
 	reqData := []byte{20, 18, 24}
 	videoGame := apifarm.VideoGame{
-		Name:         "Lady's Quest 3",
-		DateReleased: apifarm.CustomTime{time.Now()},
+		uint(0),
+		"Lady's Quest 3",
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		apifarm.CustomTime{time.Now()},
 	}
 	storedVideoGame := apifarm.VideoGame{
 		ID:           1,

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -462,6 +462,35 @@ func TestVideoGameServiceUpdateNotFound(t *testing.T) {
 	mockQueryFactory.AssertExpectations(t)
 }
 
+func TestVideoGameServiceUpdateInvalidAttributeFailure(t *testing.T) {
+	// Arrange
+	mockStorage := new(mocks.DB)
+	mockJSON := new(mocks.DataUtils)
+	mockQueryFactory := new(mocks.QueryFactory)
+
+	subject := apifarm.NewVideoGameServiceWithUtils(mockStorage, mockJSON, mockQueryFactory)
+
+	id := uint(5)
+	reqData := []byte{13, 34, 22}
+	invalidAttribute := "testers"
+	videoGameToUpdate := apifarm.VideoGame{}
+	err := &apifarm.InvalidAttributeError{Attribute: invalidAttribute}
+	expectedQuery := apifarm.Query{}
+
+	mockStorage.On("GetVideoGame", id).Return(&videoGameToUpdate)
+	mockJSON.On("DeserializeVideoGame", reqData).Return(nil, err)
+	mockQueryFactory.On("BuildMessage", apifarm.VideoGameInvalidAttribute(invalidAttribute), uint(400)).Return(expectedQuery)
+
+	// Act
+	actualQuery := subject.Update(id, reqData)
+
+	// Assert
+	assert.Equal(t, expectedQuery, actualQuery)
+	mockStorage.AssertExpectations(t)
+	mockJSON.AssertExpectations(t)
+	mockQueryFactory.AssertExpectations(t)
+}
+
 func TestVideoGameServiceUpdateInvalidDateFailure(t *testing.T) {
 	// Arrange
 	mockStorage := new(mocks.DB)

--- a/go/mux/src/service_test.go
+++ b/go/mux/src/service_test.go
@@ -423,10 +423,10 @@ func TestVideoGameServiceUpdateSuccessful(t *testing.T) {
 	serializedUpdatedVideoGame := []byte{12, 21, 35}
 	expectedQuery := apifarm.Query{}
 
-	mockJSON.On("DeserializeVideoGame", reqData).Return(&videoGameToUpdateWith, nil)
 	mockStorage.On("GetVideoGame", id).Return(&videoGameToUpdate)
+	mockJSON.On("DeserializeVideoGame", reqData).Return(&videoGameToUpdateWith, nil)
 	mockStorage.On("UpdateVideoGame", updatedVideoGame).Return(&updatedVideoGame)
-	mockJSON.On("Serialize", updatedVideoGame).Return(serializedUpdatedVideoGame)
+	mockJSON.On("Serialize", &updatedVideoGame).Return(serializedUpdatedVideoGame, nil)
 	mockQueryFactory.On("BuildResult", serializedUpdatedVideoGame, uint(0)).Return(expectedQuery)
 
 	// Act


### PR DESCRIPTION
Endpoint for updating an existing VideoGame resource with key value JSON.
Ran into problem while linting with `dupl`. Claimed to find identical lines within test, must work off threshold as the test functions are different. I've added `//nolint: dupl` comments to functions which were causing the problem.